### PR TITLE
webapp/map: add OpenStreetMap attribution to Leaflet slippy map

### DIFF
--- a/webapp/src/views/Map.vue
+++ b/webapp/src/views/Map.vue
@@ -15,7 +15,7 @@
       :use-global-leaflet="false"
       @update:bounds="updateBounds"
       @ready="mapLoaded"
-      :options="{ zoomControl: false, attributionControl: false }"
+      :options="{ zoomControl: false }"
     >
       <l-control position="topleft">
         <form @submit.prevent="onSearch">
@@ -47,8 +47,9 @@
         :url="mapTileUrl"
         layer-type="base"
         name="OpenStreetMap"
+        :attribution="attribution"
       />
-      
+
       <l-control position="bottomright">
         <v-btn @click="goToUserLocation" icon class="mt-2">
           <v-icon x-large>mdi-crosshairs-gps</v-icon>
@@ -92,6 +93,7 @@ const searchField: Ref<any|null> = ref(null);
 const searchQuery: Ref<string> = ref('');
 const router = useRouter();
 const { xs } = useDisplay();
+const attribution = '&copy; <a target="_blank" href="http://osm.org/copyright">OpenStreetMap</a> contributors'
 
 const canRefreshMarkers = computed(() => zoom.value >= MIN_ZOOM_FOR_REFRESH);
 const mapTileUrl = computed(() =>


### PR DESCRIPTION
Add attribution to the slippy map, formatted as shown in the VueJS
Leaflet docs: https://vue2-leaflet.netlify.app/quickstart/
![image](https://github.com/user-attachments/assets/1bb61cfb-e797-4cef-bee3-fecad06d9437)

The [ODbL](https://opendatacommons.org/licenses/odbl/1-0/) requires attribution
to be included alongside the map, stated in clause 4.3:
> You must include a notice associated with the Produced Work reasonably
> calculated to make any Person that uses, views, accesses, interacts with, or
> is otherwise exposed to the Produced Work aware that Content was obtained
> from the Database, Derivative Database, or the Database as part of a
> Collective Database, and that it is available under this License.

See also https://wiki.openstreetmap.org/wiki/Community_attribution_advice

Signed-off-by: Galen CC <galen8183@gmail.com>
