### PR TITLE
Faces Northwest was set to 'NE' in popup array

### DIFF
--- a/webapp/src/components/DFMapPopup.vue
+++ b/webapp/src/components/DFMapPopup.vue
@@ -83,7 +83,7 @@ const cardinalDirection = computed(() => {
 );
 
 function degreesToCardinal(degrees: number): string {
-  const cardinals = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NE'];
+  const cardinals = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
   return 'Faces ' + cardinals[Math.round(degrees / 45) % 8];
 }
 


### PR DESCRIPTION
Noticed that a northwest-facing camera was noted as "NE" in the pop-up. Fixed the array list.