### PR TITLE
Fixed the two issues I reported

### DIFF
--- a/webapp/src/components/DFMapPopup.vue
+++ b/webapp/src/components/DFMapPopup.vue
@@ -83,8 +83,8 @@ const cardinalDirection = computed(() => {
 );
 
 function degreesToCardinal(degrees: number): string {
-  const cardinals = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NE'];
-  return 'Faces ' + cardinals[Math.round(degrees / 45) % 8];
+  const cardinals = ['N','NNE','NE','ENE','E','ESE','SE','SSE','S','SSW','SW','WSW','W','WNW','NW','NNW'];
+  return 'Faces ' + cardinals[Math.round(degrees / 45) % 16];
 }
 
 function osmNodeLink(id: string): string {

--- a/webapp/src/components/DFMapPopup.vue
+++ b/webapp/src/components/DFMapPopup.vue
@@ -71,7 +71,7 @@ const props = defineProps({
 const isFaceRecognition = computed(() => props.alpr.tags.brand === 'Avigilon');
 
 const cardinalDirection = computed(() => {
-  const direction = props.alpr.tags.direction || props.alpr.tags["camera:direction"];
+  const direction =  props.alpr.tags["camera:direction"] || props.alpr.tags.direction;
   if (direction === undefined) {
     return 'Unspecified Direction';
   } else if (direction.includes(';')) {

--- a/webapp/src/components/DFMapPopup.vue
+++ b/webapp/src/components/DFMapPopup.vue
@@ -84,7 +84,7 @@ const cardinalDirection = computed(() => {
 
 function degreesToCardinal(degrees: number): string {
   const cardinals = ['N','NNE','NE','ENE','E','ESE','SE','SSE','S','SSW','SW','WSW','W','WNW','NW','NNW'];
-  return 'Faces ' + cardinals[Math.round(degrees / 45) % 16];
+  return 'Faces ' + cardinals[Math.round(degrees / 22.5) % 16];
 }
 
 function osmNodeLink(id: string): string {

--- a/webapp/src/components/LeafletMap.vue
+++ b/webapp/src/components/LeafletMap.vue
@@ -62,7 +62,7 @@ let currentLocationLayer: FeatureGroup;
 
 // Marker Creation Utilities
 function createSVGMarkers(alpr: ALPR): string {
-  const orientationValues = (alpr.tags.direction || alpr.tags['camera:direction'] || '')
+  const orientationValues = (alpr.tags['camera:direction'] || alpr.tags.direction || '')
     .split(';')
     .map(val => /^\d+$/.test(val) ? parseInt(val) : cardinalToDegrees(val.trim()));
 
@@ -89,13 +89,21 @@ function createSVGMarkers(alpr: ALPR): string {
 function cardinalToDegrees(cardinal: string): number {
   const cardinalMap: Record<string, number> = {
     N: 0,
+    NNE: 22.5,
     NE: 45,
+    ENE: 67.5,
     E: 90,
+    ESE: 112.5,
     SE: 135,
+    SSE: 157.5,
     S: 180,
+    SSW: 202.5,
     SW: 225,
+    WSW: 247.5,
     W: 270,
+    WNW: 292.5,
     NW: 315,
+    NNW: 337.5
   };
   return cardinalMap[cardinal] ?? cardinal;
 }

--- a/webapp/src/components/LeafletMap.vue
+++ b/webapp/src/components/LeafletMap.vue
@@ -89,21 +89,21 @@ function createSVGMarkers(alpr: ALPR): string {
 function cardinalToDegrees(cardinal: string): number {
   const cardinalMap: Record<string, number> = {
     N: 0,
-    NNE: 22.5,
+    NNE: 22,
     NE: 45,
-    ENE: 67.5,
+    ENE: 67,
     E: 90,
-    ESE: 112.5,
+    ESE: 112,
     SE: 135,
-    SSE: 157.5,
+    SSE: 157,
     S: 180,
-    SSW: 202.5,
+    SSW: 202,
     SW: 225,
-    WSW: 247.5,
+    WSW: 247,
     W: 270,
-    WNW: 292.5,
+    WNW: 292,
     NW: 315,
-    NNW: 337.5
+    NNW: 337
   };
   return cardinalMap[cardinal] ?? cardinal;
 }

--- a/webapp/src/components/LeafletMap.vue
+++ b/webapp/src/components/LeafletMap.vue
@@ -89,21 +89,21 @@ function createSVGMarkers(alpr: ALPR): string {
 function cardinalToDegrees(cardinal: string): number {
   const cardinalMap: Record<string, number> = {
     N: 0,
-    NNE: 22,
+    NNE: 22.5,
     NE: 45,
-    ENE: 67,
+    ENE: 67.5,
     E: 90,
-    ESE: 112,
-    SE: 135,
-    SSE: 157,
+    ESE: 112.5,
+    SE: 135.5,
+    SSE: 157.5,
     S: 180,
-    SSW: 202,
+    SSW: 202.5,
     SW: 225,
-    WSW: 247,
+    WSW: 247.5,
     W: 270,
-    WNW: 292,
+    WNW: 292.5,
     NW: 315,
-    NNW: 337
+    NNW: 337.5
   };
   return cardinalMap[cardinal] ?? cardinal;
 }


### PR DESCRIPTION
I fixed the two issues I reported. With these changes, Deflock webapp attempts to pull `camera:direction` first, moving on to `direction` if it doesn't find one, and then defaulting to blank value.

Also implements all 16 cardinal directions instead of merely 8