### PR TITLE
Upgrade python to 3.14

### DIFF
--- a/serverless/alpr_clusters/src/Dockerfile
+++ b/serverless/alpr_clusters/src/Dockerfile
@@ -1,5 +1,5 @@
-# Use the official AWS Lambda Python 3.9 base image
-FROM amazon/aws-lambda-python:3.9
+# Use the official AWS Lambda Python 3.14 base image
+FROM amazon/aws-lambda-python:3.14-x86_64
 
 # Copy function code
 COPY alpr_clusters.py ${LAMBDA_TASK_ROOT}

--- a/terraform/modules/alpr_counts/main.tf
+++ b/terraform/modules/alpr_counts/main.tf
@@ -66,7 +66,7 @@ resource "aws_lambda_function" "overpass_lambda" {
   function_name    = var.module_name
   role             = aws_iam_role.lambda_role.arn
   handler          = "${var.module_name}.lambda_handler"
-  runtime          = "python3.9"
+  runtime          = "python3.14"
   source_code_hash = data.archive_file.python_lambda_package.output_base64sha256
   timeout = 60
 }


### PR DESCRIPTION
Upgrade python to 3.14 due to 3.9 EOL

- AWS Lambda support for python3.9 ends on December 15, 2025
  -  https://repost.aws/articles/ARRCAyrRH9TTGsKWasFzdbdw/automated-migration-script-for-aws-lambda-python-3-9-end-of-support
- python3.9 as a whole is EOL as of October 31, 2025
  - https://devguide.python.org/versions/