### PR TITLE
Add robots.txt for SEO

### DIFF
--- a/webapp/public/robots.txt
+++ b/webapp/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
- Addresses #61 
- Improves Lighthouse SEO score from 67 to 75.

Before:
<img width="745" height="133" alt="Screenshot 2025-11-23 at 7 06 32 PM" src="https://github.com/user-attachments/assets/bacdc341-2fd3-4905-b1e7-a456d5f739ee" />

After:
<img width="743" height="348" alt="Screenshot 2025-11-23 at 7 29 39 PM" src="https://github.com/user-attachments/assets/c4813487-66f1-4a76-8e3f-fa9c93212120" />

```
Lighthouse 12.8.2
Chromium 142.0.0.0
```