### PR TITLE
Unify project docs with CLAUDE.md as single source of truth

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,48 +1,29 @@
 # Copilot Instructions
 
-This monorepo contains multiple subprojects. Below are the specific instructions for each.
+DeFlock — crowdsourced ALPR mapping tool. See `CLAUDE.md` for full project documentation, commands, architecture, and data flow.
 
-## Web Application
-/webapp
+## Conventions
 
-This is a TypeScript + Vue 3 + Vuetify application.
+- Functional patterns; simple and readable over clever
+- No tracking, analytics, or telemetry; never log PII
+- No placeholder logic; use `TODO` comments for unknowns
+- The Scala backend (`shotgun/`) is deprecated and deleted; do not recreate it
 
-### Architecture
-- Vue 3 (Composition API)
-- State management is local-first; avoid global stores unless required
-- Vuetify for UI components and styling
+### Frontend (webapp/)
 
-### Page Structure
-- Each page resides in `src/views`
-- Shared components go in `src/components`
-- Styles are scoped to components; avoid global styles unless necessary
-- Prefer helper classes (provided by Vuetify) for styling over CSS rules
-- Wrap most pages in DefaultLayout.vue for consistent headers/footers
-- Use the Hero component for prominent page headings
+- Vue 3 Composition API; local-first state (Pinia only when truly global)
+- Vuetify helper classes over custom CSS; always scoped styles
+- Pages in `src/views/`, shared components in `src/components/`
+- Wrap pages in `DefaultLayout.vue`; use `Hero` component for page headings
 
-### Coding Style
-- Prefer functional patterns
+### API (api/)
 
-### Security & Privacy
-- Never log PII
-- Do not introduce tracking, analytics, or telemetry
+Fastify + TypeScript on Bun. See `api/README.md` for endpoints.
 
-### General Rules
-- Do not generate placeholder logic
-- If something is unknown, leave a TODO comment
-- Prefer simple, readable solutions over clever ones
+### Serverless (serverless/)
 
-## Backend Service
-/shotgun
+Python 3.14 AWS Lambda functions. Deployed via Terraform.
 
-This is being deprecated. No new features should be added. Backend functionality should be migrated to serverless functions where possible.
+### Infrastructure (terraform/)
 
-## Terraform
-/terraform
-
-This contains Terraform code for infrastructure management.
-
-## Serverless Functions
-/serverless
-
-This contains serverless functions to support the web application.
+Terraform for AWS resource management.

--- a/.gitignore
+++ b/.gitignore
@@ -46,10 +46,11 @@ serverless/*/lambda.zip
 serverless/*/.build/
 serverless/*/src/*
 !serverless/*/src/alpr_cache.py
-!serverless/*/src/alpr_clusters.py
+!serverless/*/src/alpr_counts.py
 !serverless/*/src/requirements.txt
 !serverless/*/src/Dockerfile
 
 # TODO: need a better way to handle python packages
 
 .env
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,108 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+DeFlock is a crowdsourced tool for locating and reporting Automatic License Plate Reader (ALPR) cameras, built on OpenStreetMap data. Live at https://deflock.org.
+
+## Quick Start
+
+```bash
+# Frontend
+cd webapp && npm install && npm run dev        # http://localhost:5173
+
+# API (requires Bun)
+cd api && bun install && bun server.ts         # http://localhost:3000
+```
+
+## Build & Check
+
+```bash
+# Frontend
+cd webapp
+npm run build            # Production build (Vite)
+npm run type-check       # vue-tsc
+
+# Serverless (Python 3.14)
+cd serverless/alpr_counts/src && pip install -r requirements.txt && python alpr_counts.py
+cd serverless/alpr_cache/src  && pip install -r requirements.txt && python alpr_cache.py
+cd serverless/blog_scraper && uv sync && uv run main.py
+
+# Infrastructure
+cd terraform && terraform plan && terraform apply
+```
+
+## Repo Layout
+
+```
+webapp/          Vue 3 + TypeScript + Vuetify frontend (npm/Vite)
+api/             Fastify + TypeScript API (Bun runtime)
+serverless/
+  alpr_counts/   Python — hourly ALPR count aggregation
+  alpr_cache/    Python — daily map tile cache generation
+  blog_scraper/  Python (uv) — RSS-to-Directus CMS sync
+terraform/       AWS infra (Lambda, S3, CloudWatch, SNS)
+scripts/         Utilities (Directus backup)
+```
+
+## Conventions
+
+- Functional patterns; simple and readable over clever
+- No tracking, analytics, or telemetry; never log PII
+- No placeholder logic; use `TODO` comments for unknowns
+- The Scala backend (`shotgun/`) is deprecated and deleted; do not recreate it
+
+### Frontend-specific
+
+- Vue 3 Composition API; local-first state (Pinia only when truly global)
+- Vuetify helper classes over custom CSS; always scoped styles
+- Pages in `src/views/`, shared components in `src/components/`
+- Wrap pages in `DefaultLayout.vue`; use `Hero` component for page headings
+
+## Architecture
+
+### Data Flow
+
+```
+Overpass API ──daily──▶ alpr_cache Lambda ──▶ S3 tile JSONs ──▶ Leaflet map (webapp)
+Overpass API ──hourly─▶ alpr_counts Lambda ─▶ S3 counts JSON ─▶ ALPRCounter (webapp)
+RSS feed ──30 min────▶ blog_scraper Lambda ─▶ Directus CMS ───▶ Blog views (webapp)
+```
+
+The frontend reads pre-cached data from S3 and Directus — it never queries Overpass directly.
+
+### Frontend (webapp/)
+
+- Leaflet with marker clustering (`LeafletMap.vue`) renders ALPR locations from S3 tile JSONs
+- Types in `src/types.ts` (ALPR, LprVendor); constants in `src/constants.ts`
+- Stores in `src/stores/` — `global`, `tiles`, `vendorStore`
+
+### API (api/)
+
+- Fastify with TypeBox schema validation
+- `/geocode?query=...` — Nominatim proxy with file-based 24-hour cache
+- `/sponsors/github?username=...` — GitHub GraphQL (requires `GITHUB_TOKEN` in `.env`)
+- `/healthcheck` — HEAD only
+
+### Serverless Functions
+
+All are Python 3.14 AWS Lambdas deployed via Terraform (not GitHub Actions).
+
+- **alpr_counts** — Queries Overpass for US ALPR counts, fetches "recent wins" from Directus, writes JSON to S3. Uses threading.
+- **alpr_cache** — Queries Overpass for all ALPR nodes globally, segments into 20-degree tiles, filters to whitelisted OSM tags, uploads per-tile JSONs + index to S3. Uses ThreadPoolExecutor.
+- **blog_scraper** — Parses `haveibeenflocked.com/feed.xml` RSS, syncs to Directus `blog` collection. Idempotent: creates, updates, deletes. Preserves manually-created posts (those without `externalUrl`).
+
+## Deployment
+
+- **Frontend**: Static build (`npm run build` produces `dist/`)
+- **API**: GitHub Actions on push to `master` — rsync to VPS, restart `deflock-api` systemd service
+- **Lambdas**: `terraform apply` from `terraform/` (target individual modules with `-target=module.<name>`)
+
+## Environment Variables
+
+| Component | Variable | Required | Notes |
+|---|---|---|---|
+| api/ | `GITHUB_TOKEN` | Yes | GitHub sponsors endpoint |
+| blog_scraper | `DIRECTUS_API_TOKEN` | Yes | Directus CMS access |
+| blog_scraper | `DIRECTUS_BASE_URL` | No | Defaults to `https://cms.deflock.me` |
+| terraform/ | `directus_api_token` | Yes | In `terraform.tfvars` (gitignored) |
+| terraform/ | `alarm_phone_number` | Yes | SNS failure alerts |

--- a/README.md
+++ b/README.md
@@ -21,22 +21,20 @@ See photos of common ALPRs and learn about their capabilities.
 
 ## Tech Stack
 
-### Backend
-* Scala
-* PekkoHTTP
-* Nginx
+### API
+* Fastify + TypeScript (Bun runtime)
 
 ### Cloud
-* AWS Lambda (for [region segmenting](serverless/alpr_clusters) and [counts](serverless/alpr_counts))
+* AWS Lambda (for [map tile caching](serverless/alpr_cache), [counts](serverless/alpr_counts), and [blog sync](serverless/blog_scraper))
 * AWS S3
 * AWS ECR
-* Cloudflare as DNS + Proxy
-* Directus CDN
+* Cloudflare DNS + Proxy
+* Directus CMS
 
 ### Frontend
 * Vue3
 * Vuetify (UI component library)
-* Vue Leaflet (mapping library)
+* Leaflet (mapping library)
 
 ### Services
 * OpenStreetMap - Overpass API, Basic Map Tiles
@@ -45,8 +43,8 @@ See photos of common ALPRs and learn about their capabilities.
 ## Usage
 
 ### Requirements
-* node/npm
-* scala/sbt
+* node/npm (frontend)
+* [Bun](https://bun.sh/) (API)
 
 ### Running Frontend
 
@@ -54,18 +52,11 @@ See photos of common ALPRs and learn about their capabilities.
 2. `npm i`
 3. `npm run dev`
 
-### Running Backend
+### Running API
 
-#### Prerequisites
-* JDK 11
-* SBT
-
-1. `cd shotgun`
-2. `sbt run`
-
-### Building for Production
-
-See [Dockerfile](./Dockerfile).
+1. `cd api`
+2. `bun install`
+3. `bun server.ts`
 
 ## Contributing
 

--- a/serverless/README.md
+++ b/serverless/README.md
@@ -1,3 +1,3 @@
 # Serverless
 
-These microservices collect additional data used in DeFlock, such as total ALPR counts and map clusters.
+These microservices collect additional data used in DeFlock, such as total ALPR counts and map tile caches.

--- a/serverless/alpr_cache/README.md
+++ b/serverless/alpr_cache/README.md
@@ -1,6 +1,6 @@
-# ALPR Clusters
+# ALPR Cache
 
-Generates clusters (the blobs shown on the map when zoomed out far) daily using OSM data. OSM's Overpass API is used to query for all locations of ALPRs, then a clustering algorithm is used. The clustered data is stored in a JSON file in an S3 bucket.
+Generates map tile cache files daily using OSM data. OSM's Overpass API is used to query for all ALPR locations, then results are segmented into geographic tiles. The tile data is stored as JSON files in an S3 bucket.
 
 ## Deploying
 To build and deploy the Docker image, run `./deploy.sh`.


### PR DESCRIPTION
## Summary

Project documentation was scattered across multiple files with stale and conflicting information. This PR consolidates everything into a single authoritative source (`CLAUDE.md`) and brings the remaining docs up to date.

### What changed

- **Add `CLAUDE.md`** — comprehensive project reference covering quick start, build commands, repo layout, conventions, architecture, data flow, deployment, and environment variables. Acts as the single source of truth for both human contributors and AI coding assistants.
- **Slim down `.github/copilot-instructions.md`** — now a lightweight entry point that inlines key conventions and defers to `CLAUDE.md` for depth, eliminating duplication.
- **Fix `README.md`** — replace stale Scala/shotgun tech stack references with the current Fastify + Bun API; fix broken `serverless/alpr_clusters` link.
- **Fix serverless docs** — rename "ALPR Clusters" → "ALPR Cache" in `serverless/README.md` and `serverless/alpr_cache/README.md` to match the current tile-based caching approach.
- **Fix `.gitignore`** — replace stale `alpr_clusters.py` exception with `alpr_counts.py`; add `.claude/` directory.

### Why this matters

- **Reduces onboarding friction** — new contributors get accurate, consolidated docs instead of piecing together outdated fragments.
- **Improves AI-assisted development** — `CLAUDE.md` is the standard entrypoint for Claude Code, GitHub Copilot, and similar tools, giving them correct context about the project's architecture and conventions.
- **Eliminates stale references** — the Scala backend (`shotgun/`) has been gone for a while but was still referenced in `README.md` and elsewhere.

## Test plan

- [x] Verified all documented commands, paths, and conventions against the current codebase
- [x] Confirmed no stale references to `alpr_clusters`, `shotgun`, or Scala remain
- [x] Fixed inaccurate "US + worldwide" claim in alpr_counts description (currently US-only)
- [ ] Review rendered markdown in each changed file for formatting/readability

🤖 Generated with [Claude Code](https://claude.com/claude-code)