### PR TITLE
Fix camera popup crash when only surveillance:operator is set

### DIFF
--- a/webapp/src/components/DFMapPopup.vue
+++ b/webapp/src/components/DFMapPopup.vue
@@ -101,7 +101,7 @@ const abbreviatedOperator = computed(() => {
     "Sheriffs Office": "SO",
   };
 
-  const operator = props.alpr.tags.operator;
+  const operator = props.alpr.tags[operatorTagKey];
   for (const [full, abbr] of Object.entries(replacements)) {
     if (operator.includes(full)) {
       return operator.replace(full, abbr);


### PR DESCRIPTION
In `DFMapPopup.vue`, `abbreviatedOperator` finds the matching operator tag key (`operator` or `surveillance:operator`) but then reads `tags.operator` directly. For a node tagged only with `surveillance:operator`, that value is `undefined` and the following `operator.includes(...)` throws, leaving a broken/empty popup. This reads the matched key (`tags[operatorTagKey]`) instead.