### PR TITLE
Fix GraphQL query injection in /sponsors/github

### DIFF
--- a/api/server.ts
+++ b/api/server.ts
@@ -208,7 +208,8 @@ const start = async () => {
       querystring: {
         type: 'object',
         properties: {
-          username: { type: 'string', default: 'frillweeman' },
+          // GitHub usernames are 1-39 chars of letters, digits, and hyphens.
+          username: { type: 'string', pattern: '^[A-Za-z0-9-]{1,39}$', default: 'frillweeman' },
         },
       },
       response: {

--- a/api/services/GithubClient.test.ts
+++ b/api/services/GithubClient.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'bun:test';
+import { buildSponsorsQuery } from './GithubClient';
+
+describe('buildSponsorsQuery', () => {
+  it('parameterizes the username instead of interpolating it', () => {
+    const { query, variables } = buildSponsorsQuery('frillweeman');
+    expect(query).toContain('query($login: String!)');
+    expect(query).toContain('user(login: $login)');
+    expect(variables).toEqual({ login: 'frillweeman' });
+  });
+
+  it('never places the raw username inside the query string', () => {
+    const { query } = buildSponsorsQuery('octocat');
+    // The query is fixed and only references the $login variable — the caller's
+    // value must not appear in the query text itself.
+    expect(query).not.toContain('octocat');
+  });
+
+  it('keeps GraphQL-breaking input confined to the variables (injection guard)', () => {
+    // A username containing a quote used to break out of the interpolated
+    // string literal. It must now travel only in `variables.login`.
+    const hostile = '") { viewer { login } } #';
+    const { query, variables } = buildSponsorsQuery(hostile);
+    expect(variables.login).toBe(hostile);
+    expect(query).not.toContain(hostile);
+    expect(query).not.toContain('viewer');
+  });
+
+  it('requests sponsorships and the expected sponsor fields', () => {
+    const { query } = buildSponsorsQuery('frillweeman');
+    expect(query).toContain('sponsorshipsAsMaintainer(first: 100)');
+    for (const field of ['login', 'name', 'avatarUrl', 'url']) {
+      expect(query).toContain(field);
+    }
+  });
+});

--- a/api/services/GithubClient.ts
+++ b/api/services/GithubClient.ts
@@ -17,10 +17,18 @@ export type Sponsor = Static<typeof SponsorSchema>;
 
 export const SponsorsResponseSchema = Type.Array(SponsorSchema);
 
+// Pass the username as a GraphQL variable rather than interpolating it into the
+// query string, so a value containing quotes or other GraphQL syntax cannot
+// break out of the string literal and alter the query.
+export const buildSponsorsQuery = (username: string): { query: string; variables: { login: string } } => ({
+  query: `query($login: String!) { user(login: $login) { sponsorshipsAsMaintainer(first: 100) { nodes { sponsor { login name avatarUrl url } } } } }`,
+  variables: { login: username },
+});
+
 export class GithubClient {
   async getSponsors(username: string): Promise<Sponsor[]> {
-    const query = `query { user(login: "${username}") { sponsorshipsAsMaintainer(first: 100) { nodes { sponsor { login name avatarUrl url } } } } }`;
-    const body = JSON.stringify({ query, variables: '' });
+    const { query, variables } = buildSponsorsQuery(username);
+    const body = JSON.stringify({ query, variables });
     const response = await fetch(graphQLEndpoint, {
       method: 'POST',
       headers: {


### PR DESCRIPTION
# Fix GraphQL query injection in `/sponsors/github`

## What

`GithubClient.getSponsors()` built its GitHub GraphQL query by interpolating the
`username` request parameter directly into the query string:

```ts
const query = `query { user(login: "${username}") { ... } }`;
```

The `/sponsors/github` route validated `username` only as `type: string` (no
pattern), so a value containing a `"` breaks out of the string literal and can
alter the structure of the query sent to GitHub's GraphQL API with the server's
token. The realistic impact depends on that token's scope — at minimum it allows
tampering with the query structure and burning GitHub API quota on the shared
token. (Might be worth confirming what `GITHUB_TOKEN` is scoped to; if it's
broader than sponsors-read the ceiling is higher. I couldn't check that from
outside the deploy.)

## Fix

Two changes:

- **Parameterize the username** as a GraphQL variable (`$login: String!`) so its
  value can never alter the query document:
  ```ts
  query($login: String!) { user(login: $login) { ... } }
  ```
- **Validate `username` at the route** against GitHub's username shape
  (`^[A-Za-z0-9-]{1,39}$`) as defense-in-depth, rejecting malformed input before
  it reaches the API.

The query construction is extracted into a small pure `buildSponsorsQuery()`
helper so it can be unit-tested without a live network call. Returned data is
unchanged for legitimate usernames.

## Tests

Adds `api/services/GithubClient.test.ts`, using bun's built-in test runner (no
new dependencies). It asserts the query is parameterized, that caller input never
appears in the query text, and that a quote-containing username stays confined to
`variables`.

```
cd api && bun test
# 4 pass, 0 fail
```
