### PR TITLE
Add taginfo project file (deflock.org/taginfo.json)

### DIFF
--- a/webapp/public/taginfo.json
+++ b/webapp/public/taginfo.json
@@ -1,0 +1,105 @@
+{
+  "data_format": 1,
+  "data_url": "https://deflock.org/taginfo.json",
+  "project": {
+    "name": "DeFlock",
+    "description": "Crowdsourced map of automated license plate readers (ALPRs) and other public surveillance cameras.",
+    "project_url": "https://deflock.org",
+    "doc_url": "https://deflock.org/what-is-an-alpr",
+    "icon_url": "https://deflock.org/deflock-logo.svg",
+    "contact_name": "DeFlock",
+    "contact_email": "contact@deflock.org"
+  },
+  "tags": [
+    {
+      "key": "man_made",
+      "value": "surveillance",
+      "object_types": ["node"],
+      "description": "Base tag identifying the node as a surveillance device."
+    },
+    {
+      "key": "surveillance:type",
+      "value": "ALPR",
+      "object_types": ["node"],
+      "description": "Identifies the surveillance device as an Automated License Plate Reader."
+    },
+    {
+      "key": "surveillance",
+      "value": "public",
+      "object_types": ["node"],
+      "description": "Indicates the device surveils a publicly accessible area."
+    },
+    {
+      "key": "camera:type",
+      "value": "fixed",
+      "object_types": ["node"],
+      "description": "The camera has a fixed field of view rather than pan/tilt/zoom."
+    },
+    {
+      "key": "surveillance:zone",
+      "value": "traffic",
+      "object_types": ["node"],
+      "description": "The camera monitors road traffic."
+    },
+    {
+      "key": "camera:direction",
+      "object_types": ["node"],
+      "description": "Compass direction, in degrees, that the camera faces."
+    },
+    {
+      "key": "camera:mount",
+      "object_types": ["node"],
+      "description": "How or where the camera is mounted (for example on a pole or mast)."
+    },
+    {
+      "key": "electricity",
+      "object_types": ["node"],
+      "description": "Power source for the camera."
+    },
+    {
+      "key": "direction",
+      "object_types": ["node"],
+      "description": "Compass direction the camera faces; preserved when present."
+    },
+    {
+      "key": "operator",
+      "object_types": ["node"],
+      "description": "Organization that operates the camera."
+    },
+    {
+      "key": "surveillance:operator",
+      "object_types": ["node"],
+      "description": "Organization that operates the surveillance camera."
+    },
+    {
+      "key": "manufacturer",
+      "object_types": ["node"],
+      "description": "Manufacturer of the camera hardware."
+    },
+    {
+      "key": "surveillance:manufacturer",
+      "object_types": ["node"],
+      "description": "Manufacturer of the surveillance camera."
+    },
+    {
+      "key": "brand",
+      "object_types": ["node"],
+      "description": "Brand of the camera."
+    },
+    {
+      "key": "surveillance:brand",
+      "object_types": ["node"],
+      "description": "Brand of the surveillance camera (for example Flock Safety or Motorola)."
+    },
+    {
+      "key": "wikimedia_commons",
+      "object_types": ["node"],
+      "description": "Wikimedia Commons file or category documenting the camera."
+    },
+    {
+      "key": "note",
+      "object_types": ["node"],
+      "description": "Freeform note about the ALPR."
+    }
+  ]
+}

--- a/webapp/public/taginfo.json
+++ b/webapp/public/taginfo.json
@@ -89,12 +89,12 @@
     {
       "key": "surveillance:brand",
       "object_types": ["node"],
-      "description": "Brand of the surveillance camera (for example Flock Safety or Motorola)."
+      "description": "Brand of the surveillance camera."
     },
     {
       "key": "wikimedia_commons",
       "object_types": ["node"],
-      "description": "Wikimedia Commons file or category documenting the camera."
+      "description": "Wikimedia Commons image of the camera."
     },
     {
       "key": "note",

--- a/webapp/public/taginfo.json
+++ b/webapp/public/taginfo.json
@@ -5,7 +5,7 @@
     "name": "DeFlock",
     "description": "Crowdsourced map of automated license plate readers (ALPRs) and other public surveillance cameras.",
     "project_url": "https://deflock.org",
-    "doc_url": "https://deflock.org/what-is-an-alpr",
+    "doc_url": "https://github.com/FoggedLens/deflock/blob/master/README.md",
     "icon_url": "https://deflock.org/deflock-logo.svg",
     "contact_name": "DeFlock",
     "contact_email": "contact@deflock.org"


### PR DESCRIPTION
## Summary

Adds a [taginfo project file](https://wiki.openstreetmap.org/wiki/Taginfo/Projects)
at `webapp/public/taginfo.json`, served at `https://deflock.org/taginfo.json`.
It enumerates the OpenStreetMap tags DeFlock reads and writes for ALPR nodes so
the project appears in [Taginfo](https://taginfo.openstreetmap.org/projects) and
the OSM community can see which tags the app relies on.

Addresses #88.

## Diff scope

- `webapp/public/taginfo.json` (new, 17 tags) — static file, served verbatim from the site root.

The tags are taken from the project's own source, not invented:
- **Write tags** — `webapp/src/constants.ts` (`lprBaseTags`): `man_made=surveillance`,
  `surveillance:type=ALPR`, `surveillance=public`, `camera:type=fixed`,
  `surveillance:zone=traffic`, plus `camera:mount`, `electricity`, `note`.
- **Read/preserved tags** — `serverless/alpr_cache/src/alpr_cache.py` (`WHITELISTED_TAGS`):
  `operator`, `manufacturer`, `direction`, `brand`, `camera:direction`,
  `surveillance:brand`, `surveillance:operator`, `surveillance:manufacturer`,
  `wikimedia_commons`.

All entries use `object_types: ["node"]`, matching how ALPRs are mapped (the
Overpass query in `alpr_cache.py` selects `node["man_made"="surveillance"]["surveillance:type"="ALPR"]`).

## Verification

Schema-validated against the official
[taginfo-project-schema.json](https://github.com/taginfo/taginfo-projects/blob/master/taginfo-project-schema.json)
(ajv + ajv-formats, draft-07):

```
VALID ✓ — conforms to taginfo project schema
tags: 17 | project fields: name,description,project_url,doc_url,icon_url,contact_name,contact_email
```

Build confirms the file ships as-is to the site root:

```
$ bun run build
✓ built in 1.89s
$ ls -l dist/taginfo.json && jq empty dist/taginfo.json
-rw-r--r--  1  3124  dist/taginfo.json
(valid JSON)
```

## What was NOT tested / remaining step

- The file is **not yet registered** with the taginfo projects list — that is a
  separate one-line PR to [`taginfo/taginfo-projects`](https://github.com/taginfo/taginfo-projects)
  pointing at `https://deflock.org/taginfo.json`, which can only be done once this
  URL is live. Happy to open that follow-up once you've deployed, or you can — your call.
- Live serving of the URL was not verified (the file isn't deployed yet); it's a
  static asset in `webapp/public/`, which Vite copies verbatim to the site root
  (confirmed in the build output above).

## Test plan

- [ ] Merge + deploy, then load `https://deflock.org/taginfo.json` and confirm it serves.
- [ ] Optionally validate at `https://taginfo.openstreetmap.org/` after registration.
