### PR TITLE
Add an OSM signup prompt to the reporting-method and app pages

### DIFF
--- a/webapp/src/views/DeflockApp.vue
+++ b/webapp/src/views/DeflockApp.vue
@@ -226,6 +226,11 @@
             </v-btn>
           </div>
           <p class="cta-note">Free download • No ads • Privacy focused</p>
+          <p class="cta-note">
+            Submitting a camera needs a free
+            <a href="https://www.openstreetmap.org/user/new" target="_blank">OpenStreetMap account</a>
+            — the app signs you in with it.
+          </p>
         </div>
       </v-container>
     </section>
@@ -819,6 +824,12 @@ const visibleScreenshots = computed(() =>
 .cta-note {
   font-size: 0.875rem;
   opacity: 0.7;
+}
+
+/* The section sits on a dark gradient, so the default link blue is unreadable. */
+.cta-note a {
+  color: inherit;
+  text-decoration: underline;
 }
 
 /* Responsive Design */

--- a/webapp/src/views/DeflockApp.vue
+++ b/webapp/src/views/DeflockApp.vue
@@ -61,6 +61,11 @@
                   <v-icon icon="mdi-open-in-new" size="small" class="ml-1" />
                 </v-btn>
               </div>
+              <p class="hero-note">
+                Submitting or editing map data requires signing up for a free
+                <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap" target="_blank">OpenStreetMap</a> account.
+                You can <a href="https://www.openstreetmap.org/user/new" target="_blank">sign up here</a> with just an email address.
+              </p>
             </div>
           </v-col>
           <v-col cols="12" md="6" class="hero-image">
@@ -226,11 +231,6 @@
             </v-btn>
           </div>
           <p class="cta-note">Free download • No ads • Privacy focused</p>
-          <p class="cta-note">
-            Submitting a camera needs a free
-            <a href="https://www.openstreetmap.org/user/new" target="_blank">OpenStreetMap account</a>
-            — the app signs you in with it.
-          </p>
         </div>
       </v-container>
     </section>
@@ -826,8 +826,14 @@ const visibleScreenshots = computed(() =>
   opacity: 0.7;
 }
 
-/* The section sits on a dark gradient, so the default link blue is unreadable. */
-.cta-note a {
+.hero-note {
+  margin-top: 24px;
+  font-size: 0.95rem;
+  opacity: 0.85;
+}
+
+/* The hero sits on a dark gradient, so the default link blue is unreadable. */
+.hero-note a {
   color: inherit;
   text-decoration: underline;
 }

--- a/webapp/src/views/ReportChoose.vue
+++ b/webapp/src/views/ReportChoose.vue
@@ -10,6 +10,16 @@
       </v-col>
     </v-row>
 
+    <v-row justify="center" class="mb-4">
+      <v-col cols="12" md="8">
+        <v-alert variant="tonal" type="info" density="comfortable">
+          Both methods save to <b>OpenStreetMap</b>, so you'll need a free account before you can
+          submit a camera.
+          <a href="https://www.openstreetmap.org/user/new" target="_blank">Sign up for an OpenStreetMap account</a>.
+        </v-alert>
+      </v-col>
+    </v-row>
+
     <!-- ALPR Identification Warning -->
     <v-row justify="center" class="mb-8">
       <v-col cols="12" class="text-center">

--- a/webapp/src/views/ReportChoose.vue
+++ b/webapp/src/views/ReportChoose.vue
@@ -13,9 +13,8 @@
     <v-row justify="center" class="mb-4">
       <v-col cols="12" md="8">
         <v-alert variant="tonal" type="info" density="comfortable">
-          Both methods save to <b><a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap" target="_blank">OpenStreetMap</a></b>,
-          so you'll need a free account before you can submit a camera.
-          <a href="https://www.openstreetmap.org/user/new" target="_blank">Sign up for an OpenStreetMap account</a>.
+          DeFlock uses <b><a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap" target="_blank">OpenStreetMap</a></b> data;
+          you'll need to <a href="https://www.openstreetmap.org/user/new" target="_blank">create an OpenStreetMap account</a> to make submissions.
         </v-alert>
       </v-col>
     </v-row>

--- a/webapp/src/views/ReportChoose.vue
+++ b/webapp/src/views/ReportChoose.vue
@@ -13,8 +13,8 @@
     <v-row justify="center" class="mb-4">
       <v-col cols="12" md="8">
         <v-alert variant="tonal" type="info" density="comfortable">
-          Both methods save to <b>OpenStreetMap</b>, so you'll need a free account before you can
-          submit a camera.
+          Both methods save to <b><a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap" target="_blank">OpenStreetMap</a></b>,
+          so you'll need a free account before you can submit a camera.
           <a href="https://www.openstreetmap.org/user/new" target="_blank">Sign up for an OpenStreetMap account</a>.
         </v-alert>
       </v-col>


### PR DESCRIPTION
Closes #86.

Both reporting methods write to OpenStreetMap, but the only "create an account" link on the site is buried in step 1 of the iD stepper on `/report/id`. Someone landing on `/report` or `/app` gets no hint they need an account until they hit the login wall. That's the gap the issue is pointing at.

Two changes:

- `ReportChoose.vue` — an info `v-alert` under the intro line, before the two method cards, saying both paths save to OSM and linking to `openstreetmap.org/user/new`.
- `DeflockApp.vue` — a line under the download CTA noting the same thing, since the issue asked about the app page too. That section sits on the purple gradient, so there's a small scoped rule making the link inherit white instead of rendering default-blue on purple.

Wording matches the existing link on `/report/id`. No new deps, no state, no telemetry.

Checked with `npm run build-only` (no bun here, and `package-lock.json` is in the repo so npm works) and rendered both pages against `vite dev`. `npm run type-check` does fail, but on `App.vue` and a `@vitejs/plugin-vue` type declaration. Both are already broken on `master` and neither is touched here.
