### PR TITLE
fix geocode cache key ignoring the geojson variant

### DIFF
--- a/api/services/NominatimClient.test.ts
+++ b/api/services/NominatimClient.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, afterEach, mock } from 'bun:test';
+import { NominatimClient } from './NominatimClient';
+
+// The disk cache lives at a fixed path and survives between runs, so each test
+// uses a query it has never cached before.
+function uniqueQuery(label: string): string {
+  return `${label} ${Date.now()} ${Math.random()}`;
+}
+
+function stubFetch(urls: string[]) {
+  global.fetch = mock(async (url: string) => {
+    urls.push(String(url));
+    const result: Record<string, unknown> = {
+      addresstype: 'city',
+      boundingbox: ['1', '2', '3', '4'],
+      class: 'place',
+      display_name: 'Springfield, IL, United States',
+      importance: 0.5,
+      lat: '39.8',
+      licence: 'test',
+      lon: '-89.6',
+      name: 'Springfield',
+      place_rank: 16,
+      type: 'city',
+    };
+    if (String(url).includes('polygon_geojson=1')) {
+      result.geojson = { type: 'Polygon', coordinates: [[[0, 0]]] };
+    }
+    return new Response(JSON.stringify([result]));
+  }) as unknown as typeof fetch;
+}
+
+describe('NominatimClient.geocodePhrase', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('does not serve a cached geojson-free result to a caller that asked for geojson', async () => {
+    const urls: string[] = [];
+    stubFetch(urls);
+    const query = uniqueQuery('Springfield');
+    const client = new NominatimClient();
+
+    await client.geocodePhrase(query, false);
+    const withGeoJson = await client.geocodePhrase(query, true);
+
+    expect(urls.length).toBe(2);
+    expect(urls[1]).toContain('polygon_geojson=1');
+    expect(withGeoJson[0]?.geojson).toBeDefined();
+  });
+
+  it('still serves repeat requests for the same variant from the cache', async () => {
+    const urls: string[] = [];
+    stubFetch(urls);
+    const query = uniqueQuery('Springfield');
+    const client = new NominatimClient();
+
+    await client.geocodePhrase(query, true);
+    await client.geocodePhrase(query, true);
+
+    expect(urls.length).toBe(1);
+  });
+});

--- a/api/services/NominatimClient.ts
+++ b/api/services/NominatimClient.ts
@@ -63,7 +63,8 @@ export class NominatimClient {
       return zipResult ? [zipResult] : [];
     }
 
-    const cacheKey = `geocode:${query}`;
+    // The geojson variant is a different response, so it needs its own key
+    const cacheKey = `geocode:${includeGeoJson ? 'geojson' : 'plain'}:${query}`;
     const cached = await cache.get(cacheKey);
     if (cached) {
       return cached as NominatimResult[];


### PR DESCRIPTION
`/geocode` and `/geocode/multi` both go through `NominatimClient.geocodePhrase`, and they ask for different things. The single endpoint passes `includeGeoJson: true` so the map can draw the city boundary; the multi endpoint passes `false`. Both then look the result up under the same cache key:

```ts
const cacheKey = `geocode:${query}`;
```

So whichever endpoint asks first wins that query for the next 24 hours. If `/geocode/multi` gets there first, a later `/geocode` for the same place is served the cached entry, which has no `geojson` on it, and no Nominatim call is made to go get it. `Map.vue` reads `result.geojson` to set the boundary polygon and to work out the zoom level, so the search quietly lands on the place with no boundary drawn.

The parameter was added in #109; the cache key is from back when there was only one variant.

The fix puts the variant in the key. I also added a test for the cached path, since there wasn't one.

## Verifying

`api/services/NominatimClient.test.ts` stubs `fetch` and counts the upstream calls. On master:

```
$ bun test services/NominatimClient.test.ts
45 |
46 |     await client.geocodePhrase(query, false);
47 |     const withGeoJson = await client.geocodePhrase(query, true);
48 |
49 |     expect(urls.length).toBe(2);
                             ^
error: expect(received).toBe(expected)

Expected: 2
Received: 1

      at <anonymous> (.../api/services/NominatimClient.test.ts:49:25)
(fail) NominatimClient.geocodePhrase > does not serve a cached geojson-free result to a caller that asked for geojson [21.03ms]

 1 pass
 1 fail
 2 expect() calls
Ran 2 tests across 1 file. [271.00ms]
```

One upstream call instead of two, because the second request came back from the cache.

With the fix, the whole `api` suite:

```
$ bun test
bun test v1.3.14 (0d9b296a)

 7 pass
 0 fail
 15 expect() calls
Ran 7 tests across 2 files. [225.00ms]
```

The second test in the file asks for the same variant twice and still expects a single upstream call, so this isn't just turning the cache off.

One thing worth flagging: the disk store lives at a fixed `/tmp/nominatim-cache` and outlives the test process, so the tests generate a query string they haven't cached before rather than assuming an empty cache. Happy to swap that for an injectable cache if you'd rather have the seam.
